### PR TITLE
Add template fields to ProduceToTopicOperator

### DIFF
--- a/airflow_provider_kafka/operators/produce_to_topic.py
+++ b/airflow_provider_kafka/operators/produce_to_topic.py
@@ -46,6 +46,8 @@ class ProduceToTopicOperator(BaseOperator):
     :type poll_timeout: float, optional
     :raises AirflowException: _description_
     """
+    
+    template_fields = ('topic', 'producer_function', 'producer_function_args', 'producer_function_kwargs')
 
     def __init__(
         self,


### PR DESCRIPTION
This change enables [Jinja templating](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html) for `ProduceToTopicOperator`. It's useful when the producer function needs access to execution context, e.g. date interval, or when it depends on the upstream result, e.g. XCom variable. Otherwise, you have to write a custom `PythonOperator` and use the Hook/Producer directly.

Example 1 - dynamically route messages to a topic based on upstream status:
```
ProduceToTopicOperator(topic="export_result_{{ ti.xcom_pull(task_ids='export_status') }}")
```
Example 2 - access the context variables, e.g. DagRun or TaskInstance, from `producer_function`:
```
def produce_messages(**context):
    return load_from_db(start_date=context['start_date'], end_date=context['end_date'])
   
ProduceToTopicOperator(producer_function_kwargs={
    "start_date": "{{ data_interval_start }}",
    "end_date": "{{ data_interval_end }}"
})
```

Tested this manually. Unfortunately, I don't know how to write a unit test for this.