### PR TITLE
Add `config` attributes to `template_fields`

### DIFF
--- a/airflow_provider_kafka/operators/await_message.py
+++ b/airflow_provider_kafka/operators/await_message.py
@@ -50,6 +50,7 @@ class AwaitKafkaMessageOperator(BaseOperator):
         "apply_function",
         "apply_function_args",
         "apply_function_kwargs",
+        "kafka_config",
     )
 
     def __init__(

--- a/airflow_provider_kafka/operators/consume_from_topic.py
+++ b/airflow_provider_kafka/operators/consume_from_topic.py
@@ -54,6 +54,7 @@ class ConsumeFromTopicOperator(BaseOperator):
         "apply_function",
         "apply_function_args",
         "apply_function_kwargs",
+        "consumer_config",
     )
 
     def __init__(

--- a/airflow_provider_kafka/operators/event_triggers_function.py
+++ b/airflow_provider_kafka/operators/event_triggers_function.py
@@ -50,6 +50,7 @@ class EventTriggersFunctionOperator(BaseOperator):
         "apply_function",
         "apply_function_args",
         "apply_function_kwargs",
+        "kafka_config",
     )
 
     def __init__(

--- a/airflow_provider_kafka/operators/produce_to_topic.py
+++ b/airflow_provider_kafka/operators/produce_to_topic.py
@@ -52,6 +52,7 @@ class ProduceToTopicOperator(BaseOperator):
         "producer_function",
         "producer_function_args",
         "producer_function_kwargs",
+        "kafka_config",
     )
 
     def __init__(


### PR DESCRIPTION
I wish to manage `kafka_config` attribute as `template_fields`.

I want to have different `bootstrap.servers` value depending on the deployment environment, such as develop, test, and production. It would be useful while managing different values in the `Variable` store for each deployment environment with the same DAG code.

For example, in the `ProduceToTopicOperator`, I can use:

```py
kafka_config={"bootstrap.servers": "{{ var.value.get('kafka__bootstrap_servers')}}"},
```